### PR TITLE
Enhancement: add husk versions

### DIFF
--- a/custom/plugins/HuskStandalone/HuskStandalone.options
+++ b/custom/plugins/HuskStandalone/HuskStandalone.options
@@ -37,6 +37,15 @@ Description="for USD we are unsure whether we need this?"
 Required=false
 DisableIfBlank=true
 
+[Version]
+Type=label
+Label=Version
+Category=Husk Version
+Index=0
+Description=Husk Version.
+Required=false
+DisableIfBlank=true
+
 [Renderer]
 Type=label
 Label=Renderer

--- a/custom/plugins/HuskStandalone/HuskStandalone.param
+++ b/custom/plugins/HuskStandalone/HuskStandalone.param
@@ -23,4 +23,22 @@ CategoryOrder=0
 Index=0
 Label=HUSK Executable
 Description=The path to the husk executable file used for rendering. Enter alternative paths on separate lines.
-Default=C:\Program Files\Side Effects Software\Houdini 18.5.596\bin\husk.exe
+Default=C:\Program Files\Side Effects Software\Houdini 20.0.000\bin\husk.exe
+
+[USD_RenderExecutable_19_5]
+Type=multilinemultifilename
+Category=Render Executables
+CategoryOrder=0
+Index=1
+Label=HUSK 19.5 Executable
+Description=The path to the husk executable file used for rendering. Enter alternative paths on separate lines.
+Default=C:\Program Files\Side Effects Software\Houdini 19.5.000\bin\husk.exe
+
+[USD_RenderExecutable_20_0]
+Type=multilinemultifilename
+Category=Render Executables
+CategoryOrder=0
+Index=2
+Label=HUSK 20.0 Executable
+Description=The path to the husk executable file used for rendering. Enter alternative paths on separate lines.
+Default=C:\Program Files\Side Effects Software\Houdini 20.0.000\bin\husk.exe

--- a/custom/plugins/HuskStandalone/HuskStandalone.py
+++ b/custom/plugins/HuskStandalone/HuskStandalone.py
@@ -70,7 +70,10 @@ class HuskStandalone(DeadlinePlugin):
 
     def RenderExecutable(self):
         """Return render executable path"""
-        return self.GetRenderExecutable("USD_RenderExecutable")
+        version = self.GetPluginInfoEntryWithDefault("Version", "")
+        if version:
+            version = "_" + version.replace(".", "_")
+        return self.GetRenderExecutable("USD_RenderExecutable" + version)
 
     def RenderArgument(self):
         """Return arguments that go after the filename in the render command"""

--- a/custom/plugins/HuskStandalone/HuskStandalone.py
+++ b/custom/plugins/HuskStandalone/HuskStandalone.py
@@ -129,7 +129,16 @@ class HuskStandalone(DeadlinePlugin):
         # They mention using the `--disable-dummy-raster-product` husk flag.
 
         arguments.append("--make-output-path")
-        arguments.append("--disable-dummy-raster-product")
+        
+        version = self.GetPluginInfoEntryWithDefault("Version", "")
+
+        # We assume no version passed will be latest version, 
+        # otherwise version would be in the form (major.minor) 
+        # where we only consider the major version.
+        if not version or float(version.split(".", 1)[0]) >= 20:
+            # Supported only on Houdini 20+. 
+            arguments.append("--disable-dummy-raster-product")
+
         return " ".join(arguments)
 
     def SingleFrameOnly(self):


### PR DESCRIPTION
## Changelog Description
Add Husk versions.
Also, fixes a bug with unimplemented flag in Houdini below 20

## Additional Info
I used this PR along with https://github.com/BigRoy/ayon-core/tree/colorbleed branch and tested it in AYON.

