### PR TITLE
Support slap comp argument

### DIFF
--- a/custom/plugins/HuskStandalone/HuskStandalone.options
+++ b/custom/plugins/HuskStandalone/HuskStandalone.options
@@ -135,6 +135,6 @@ Label=Slap Comps
 Lines=5
 Category=Additional Options
 Index=0
-Description=each line represents a slap comp source follows: slap_comp_path?option=value&option2=value2
+Description=Each line represents a slap comp source, like: slap_comp_path?option=value&option2=value2
 Required=false
 DisableIfBlank=true

--- a/custom/plugins/HuskStandalone/HuskStandalone.options
+++ b/custom/plugins/HuskStandalone/HuskStandalone.options
@@ -130,7 +130,7 @@ Required=false
 DisableIfBlank=true
 
 [SlapCompSources]
-Type=string
+Type=multilinestring
 Label=Slap Comps
 Lines=5
 Category=Additional Options

--- a/custom/plugins/HuskStandalone/HuskStandalone.options
+++ b/custom/plugins/HuskStandalone/HuskStandalone.options
@@ -135,6 +135,6 @@ Label=Slap Comps
 Lines=5
 Category=Additional Options
 Index=0
-Description=each line represents a semicolon separated slap comp follows: slap_comp_path?option=value&option2=value2
+Description=each line represents a slap comp source follows: slap_comp_path?option=value&option2=value2
 Required=false
 DisableIfBlank=true

--- a/custom/plugins/HuskStandalone/HuskStandalone.options
+++ b/custom/plugins/HuskStandalone/HuskStandalone.options
@@ -128,3 +128,13 @@ Index=0
 Description=Post-Render script to run.
 Required=false
 DisableIfBlank=true
+
+[SlapCompSources]
+Type=string
+Label=Slap Comps
+Lines=5
+Category=Additional Options
+Index=0
+Description=each line represents a semicolon separated slap comp follows: slap_comp_path?option=value&option2=value2
+Required=false
+DisableIfBlank=true

--- a/custom/plugins/HuskStandalone/HuskStandalone.py
+++ b/custom/plugins/HuskStandalone/HuskStandalone.py
@@ -140,6 +140,12 @@ class HuskStandalone(DeadlinePlugin):
             # Supported only on Houdini 20+. 
             arguments.append("--disable-dummy-raster-product")
 
+        # Slap Comp Args
+        slapcomp_sources = self.GetPluginInfoEntryWithDefault("SlapCompSources", "")
+        for source in slapcomp_sources.splitlines():
+            if source:
+                arguments.append(f"--slap-comp {source}")
+
         return " ".join(arguments)
 
     def SingleFrameOnly(self):


### PR DESCRIPTION
## Changelog Description

Add `SlapCompSources` option. 
It's a multiline option where each line follows `lap_comp_path?option=value&option2=value2`

<img width="1174" height="777" alt="image" src="https://github.com/user-attachments/assets/28549e9d-a39a-44a4-b371-15dab74a5768" />


This PR is tested along 2 other PRs:
- https://github.com/ynput/ayon-houdini/pull/301 (includes testing steps)
- https://github.com/ynput/ayon-deadline/pull/201