### PR TITLE
feat(HuskStandalone): add handler for OIIO errors

### DIFF
--- a/custom/plugins/HuskStandalone/HuskStandalone.py
+++ b/custom/plugins/HuskStandalone/HuskStandalone.py
@@ -68,6 +68,7 @@ class HuskStandalone(DeadlinePlugin):
         self.AddStdoutHandlerCallback(".*ERROR.*\[texturesys\] .* (Could not open file .*)").HandleCallback += self.HandleStdoutError  # capture error if texture can't be loaded
         self.AddStdoutHandlerCallback("USD ERROR(.*)").HandleCallback += self.HandleStdoutError  # detect usd error
         self.AddStdoutHandlerCallback(r"ALF_PROGRESS ([0-9]+(?=%))").HandleCallback += self.HandleStdoutProgress
+        self.AddStdoutHandlerCallback(".*OIIO Error: Error writing data to subimage(.*)").HandleCallback += self.HandleStdoutError  # detect OIIO error
 
     def RenderExecutable(self):
         """Return render executable path"""


### PR DESCRIPTION
We faced an issue where at some point certain jobs started to output this error message `OIIO Error: Error writing data to subimage 0`. Deadline would go on and finish the render leaving an empty frame behind and marking the job as completed.

In this PR we add a new stdout handler callback to capture this error.


<img width="1723" height="585" alt="image" src="https://github.com/user-attachments/assets/58a40863-92cc-4b05-b8b6-d1d60f60996e" />
