### PR TITLE
feat: Add tile rendering support for Husk Standalone

### DIFF
--- a/custom/plugins/HuskStandalone/HuskStandalone.options
+++ b/custom/plugins/HuskStandalone/HuskStandalone.options
@@ -138,3 +138,45 @@ Index=0
 Description=Each line represents a slap comp source, like: slap_comp_path?option=value&option2=value2
 Required=false
 DisableIfBlank=true
+
+[TileIndex]
+Type=integer
+Minimum=-1
+Maximum=1024
+Label=Tile Index
+Category=Tile Rendering
+Index=0
+Description=Index of this tile (0-based). -1 = not a tile job.
+Required=false
+DisableIfBlank=true
+
+[TilesX]
+Type=integer
+Minimum=0
+Maximum=64
+Label=Tiles X
+Category=Tile Rendering
+Index=1
+Description=Number of tiles in X (husk --tile-count X Y). 0 = not a tile job.
+Required=false
+DisableIfBlank=true
+
+[TilesY]
+Type=integer
+Minimum=0
+Maximum=64
+Label=Tiles Y
+Category=Tile Rendering
+Index=2
+Description=Number of tiles in Y (husk --tile-count X Y). 0 = not a tile job.
+Required=false
+DisableIfBlank=true
+
+[TileSuffix]
+Type=string
+Label=Tile Suffix
+Category=Tile Rendering
+Index=3
+Description=Printf pattern appended to output filenames (--tile-suffix), e.g. _tile%02d. Husk substitutes the tile index itself.
+Required=false
+DisableIfBlank=true

--- a/custom/plugins/HuskStandalone/HuskStandalone.py
+++ b/custom/plugins/HuskStandalone/HuskStandalone.py
@@ -122,6 +122,40 @@ class HuskStandalone(DeadlinePlugin):
             if value:
                 arguments.append(f"--{husk_flag} {value}")
 
+        # Tile rendering flags. Husk wants `--tile-count X Y` (two values)
+        # plus `--tile-index N` and a printf-style `--tile-suffix` like
+        # `_tile%02d` (husk substitutes the index itself). Only emitted when
+        # TilesX > 0 and TilesY > 0 (i.e. this is actually a tile job).
+        # TileIndex=0 is a real value (first tile), so we don't use the
+        # falsy-check the generic loop above uses.
+        try:
+            tiles_x = int(
+                self.GetPluginInfoEntryWithDefault("TilesX", "0")
+            )
+        except ValueError:
+            tiles_x = 0
+        try:
+            tiles_y = int(
+                self.GetPluginInfoEntryWithDefault("TilesY", "0")
+            )
+        except ValueError:
+            tiles_y = 0
+        if tiles_x > 0 and tiles_y > 0:
+            try:
+                tile_index = int(
+                    self.GetPluginInfoEntryWithDefault("TileIndex", "-1")
+                )
+            except ValueError:
+                tile_index = -1
+            if tile_index >= 0:
+                arguments.append(f"--tile-index {tile_index}")
+                arguments.append(f"--tile-count {tiles_x} {tiles_y}")
+                tile_suffix = self.GetPluginInfoEntryWithDefault(
+                    "TileSuffix", ""
+                )
+                if tile_suffix:
+                    arguments.append(f"--tile-suffix {tile_suffix}")
+
         # Default to restart delegate every frame since it's much more reliable
         # e.g. arnold just doesn't update per frame otherwise
         arguments.append("--restart-delegate 1")


### PR DESCRIPTION
- Add --tile-index, --tile-count, and --tile-suffix flags support
- Parse TilesX, TilesY, TileIndex, and TileSuffix plugin parameters
- Enable parallel tile rendering on Deadline farm